### PR TITLE
Refactor build and linting around @babel/preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "plugins": ["@babel/transform-runtime"],
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "node": "4.0.0"
+      }
+    }]
+  ]
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-**/node_modules/**
-
-**/dist/**
-demo/**
+build/
+demo/
+test/fixtures/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,59 +1,20 @@
 module.exports = {
-  // start with google standard style
-  //     https://github.com/google/eslint-config-google/blob/master/index.js
-  "extends": ["eslint:recommended", "google"],
-  "env": {
-    "node": true,
-    "es6": true
+  extends: ['eslint:recommended', 'google'],
+  env: {
+    node: true,
   },
-  "rules": {
-    // 2 == error, 1 == warning, 0 == off
-    "indent": [2, 2, {
-      "SwitchCase": 1,
-      "VariableDeclarator": 2
-    }],
-    "max-len": [2, 140, {
-      "ignoreComments": true,
-      "ignoreUrls": true,
-      "tabWidth": 2
-    }],
-    "no-empty": [2, {
-      "allowEmptyCatch": true
-    }],
-    "no-implicit-coercion": [2, {
-      "boolean": false,
-      "number": true,
-      "string": true
-    }],
-    "no-unused-expressions": [2, {
-      "allowShortCircuit": true,
-      "allowTernary": false
-    }],
-    "no-unused-vars": [2, {
-      "vars": "all",
-      "args": "after-used",
-      "argsIgnorePattern": "(^reject$|^_$)",
-      "varsIgnorePattern": "(^_$)"
-    }],
-    "quotes": [2, "single"],
-    "strict": [2, "global"],
-    "prefer-const": 2,
-
-    // Disabled rules
-    "require-jsdoc": 0,
-    "valid-jsdoc": 0,
-    "comma-dangle": 0,
-    "arrow-parens": 0,
-    // Compat: support for rest params is behind a flag for node v5.x
-    "prefer-rest-params": 0,
+  parserOptions: {
+    ecmaVersion: 2017,
   },
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "ecmaFeatures": {
-      "globalReturn": true,
-      "jsx": false,
-      "experimentalObjectRestSpread": false
-    },
-    "sourceType": "script"
+  rules: {
+    'max-len': [2, 140, {
+      ignoreComments: true,
+      ignoreUrls: true,
+      tabWidth: 2
+    }],
+    'require-jsdoc': 0,
+    'valid-jsdoc': 0,
+    'comma-dangle': 0,
+    'arrow-parens': 0,
   }
-}
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-demo/node_modules
-node_modules
-/haters
+# Directories
+node_modules/
+build/
+
+# Files
 npm-debug.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,642 @@
 {
   "name": "preload-webpack-plugin",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.38.tgz",
+      "integrity": "sha512-RF2RQh9gvxeXtwrFzgf4PKCsmCPsa/tHaL0TQ3eWRoyno91GsoYnAhh/SnvPrlvXV+9Uosw+zwOgwnVyRvPDYQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "1.7.0",
+        "commander": "2.13.0",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "2.0.0",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
+      "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "@babel/core": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.38.tgz",
+      "integrity": "sha512-xIDdSeSElby0p6QMowawWrU9VulpMk1yq6RaKYjaZBRT7s40kztTsDw8+VUVuQmdRbqLh8DpLWs15oaUWphsPg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.38",
+        "@babel/generator": "7.0.0-beta.38",
+        "@babel/helpers": "7.0.0-beta.38",
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/traverse": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38",
+        "babylon": "7.0.0-beta.38",
+        "convert-source-map": "1.5.1",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11",
+        "resolve": "1.5.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.38.tgz",
+      "integrity": "sha512-aOHQPhsEyaB6p2n+AK981+onHoc+Ork9rcAQVSUJR33wUkGiWRpu6/C685knRyIZVsKeSdG5Q4xMiYeFUhuLzA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.38",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.38.tgz",
+      "integrity": "sha512-7k67bppxvfSS+hu2yiDeuVTf8GHOlz8haHwRJZDXiXwjm2IBqEYYA6Dvi+xNMHy05pZVBy012qpS7BpguXoW4A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.38.tgz",
+      "integrity": "sha512-CgTc4zaS4dLCKIMzCP9Q4Uhy9upBCFcA3NY7ZNwF+6S8BRCcNwoyTh2eHGt5ct1tM+Vd3VI6iIORIhqYzjHuXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.38.tgz",
+      "integrity": "sha512-73K4lywDxQTHlBEcF7YJBvBMpIxd0CTvmWjJ2pVqnkMGPmLTzWLNsrDEoJdv5ri9RXT0YJIoMPlqPBsM4FBIow==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.38",
+        "@babel/traverse": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.38.tgz",
+      "integrity": "sha512-SLy0ZNnApMsZIY/F1nW2/mXHpFaYvga6aQABkwi4IACZvC17mPhh/ilJBll4lUqdXikxRwrGsZQQfJNOEhbPsA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.38.tgz",
+      "integrity": "sha512-bSaaJpH0Yt5iKlZ9KJkrZTIkyLcrRW14z9Pt5Jh+DDXzW+3/F0wfHzoPn5qlnad70LeW5OHO8J8PriRKSqLTkg==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.38.tgz",
+      "integrity": "sha512-vLOtqh2PMbvOXL/+DlwH6A2/y+81l518Z0x7232T4E8HiMBQbkv3rNg4GmjJ5M6GcZzj7UKTBrVt8AXcH4OTdA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.38",
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ty3muWaxHPcvdwihBWqGBD+s+hjt4Tua3In43eA4BvLMKWtTYsJBGdLoWQUY4TXhVgDe7wPzqxIv2AUbnIh/vQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.38.tgz",
+      "integrity": "sha512-bn4shp3AGjRDmCsq4lKxTjOWSak+3wNGaDjc9ePmk0fMfua1HcDpxQ7d84lweq6tvHMOgXK8dhu/zj36r8SNvQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.38.tgz",
+      "integrity": "sha512-A/KUU0SC25pgI7k0K4habJqOYu9sp0UsMz3lRl26cIWhaLb5e9QRfCn1nmPnkBgCjc6IZl7pOxu4511Qfo/YxQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.38",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.38.tgz",
+      "integrity": "sha512-MnluW457L9EAykzbGYTx9mF1SUXO0Brh1UrNSSGu/C+VjMXf4EmQ9RCWOaGT3WCxLVp063xS8ejkdjGwAJqIDw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.38",
+        "@babel/helper-simple-access": "7.0.0-beta.38",
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.38.tgz",
+      "integrity": "sha512-BK5wW2bh2TEFhYkXdmB4TIF75dx3OlBZSVVMbzeA9zW/lJrvnQS2a+vm8xmZI6B4aQ5myuAuwzM37Ai29EKhnw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ovwkKMmLkZspr7ge5y8w7JQoO1MXPXcp8UaLxcmP5Akw0uAmISvd4vGFy4tpwtnsgPU1N7J5NyomTdMPqn78Aw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.38.tgz",
+      "integrity": "sha512-7V2WVMz5KRLxE33p1lb4SduDxoLF8TQ4rTGi9rzpEuly8KnlLkZR0ts62hnqZYVyBB3Gq1nfOgLG56AvflBgOg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.38",
+        "@babel/helper-wrap-function": "7.0.0-beta.38",
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/traverse": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.38.tgz",
+      "integrity": "sha512-0DcCEsI03e2lkF/teZaTDHOIkYq7ATwXmGc51LYQkzgRbmEtwk5e0GxxD+IQPy1ZW4GATsIJ0i1yt4cPaSFbpA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.38",
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/traverse": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.38.tgz",
+      "integrity": "sha512-Az+xsA1KgBrnpTjpqaNoL84a2g3gZCluf45MFijTuImZtoqg3TbObOdwOnbBy/qyNYRBCJ2Qexf7hNRb2xhLaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.38.tgz",
+      "integrity": "sha512-JQY2Hc/NCuVukBavW2mA7GqWZlpScXpurmviG+hKAvxpci5ZdsmocgwOAKWpO+u18OyI0PrZ5lUTGnjlaq0j9A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.38",
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/traverse": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.38.tgz",
+      "integrity": "sha512-DNdEZABrx2oNSpqijJHjxR/V36hMIQgFkdgv/iQsJ7xhXhObIrH1FMXsd3jbnlgblTc/7/hYed6wNKYxxXX0eQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.38",
+        "@babel/traverse": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-check-constants": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.38.tgz",
+      "integrity": "sha512-MjdGn/2sMLu0fnNFbkILut0OsegzRTeCOJ/uGHH88TwTXPzxONx2cTVJ36i3cTQXHMiIOUT3hX6HqzWM99Q6vA==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ATy8xhmvnoZnB8Ycl0LwPVg1djx/7grNEdshLNmREFWvI/xyEwe8euw+H5Cwtd6E8AOPEPI2IVmMKPyWeaVeVg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.38",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.38.tgz",
+      "integrity": "sha512-hmlKGy0xyWSzfkrFee3oVDjtI1BTLiq9uaLSZHJ1q7XxyXHDrwizIJupSKuDnaIcNhNDioW26Strn9lDbo5pJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.38.tgz",
+      "integrity": "sha512-KNJb34D11ZDeOSTGI1vmIK2yRfmam4NxKrbwBPPO6yBrcSEKwR/9/kg/oa7PETLPnZcfENXu8gShD8NdaVLtrw==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.38.tgz",
+      "integrity": "sha512-6fkV/IjSly+4ALL2q7LKFqAhr/1KPmLoXf5Nk61RpyS/3+EARkJ8hsXgYtrfDDXY4SyoA10zVhhNnSnlU+LSVw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.38",
+        "regexpu-core": "4.1.3"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.38.tgz",
+      "integrity": "sha512-YboIs/srf1yKLRvZ6JoaGjpkcW3UYsPKhkPt3hWO54OVouS34A5dwK8wO3wGhvKgUvq2GV+tU4eRNkgEcx7aLA==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ecDBcMwYJaZQaj0xKJJpjvVS00HCqzvXFjdb2WrmTqjp9lrv/hlb7XLsSQsEtscbyyWgYasFkccjp5HVPN9Mtw==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.38.tgz",
+      "integrity": "sha512-682EA8vPvHjQzmt768dp214gykrVFCxybbmLOTWql7w3XMUE5x4VGiXBITvu5rAMdzr6jX9dC9wSA0tp+efcgw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.38.tgz",
+      "integrity": "sha512-MXh/RazPii5LK6E2ve3+mmeGJAcNaUW8SwVh1a5Tt92RyXbTsZtmFz0mPsVz6Otxx/C/cj8gahHfiuBpktP//w==",
+      "dev": true
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.38.tgz",
+      "integrity": "sha512-l3A58LHNzp/Q1l8SdinAoSNsCwR0Fe3YG8y+N19IAYG/wD5NWyYobTv19UXePe9RmPLg3dUBSTwGAcMXwZrxFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.38",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.38.tgz",
+      "integrity": "sha512-pmun01vKbbZTlmyv68dYPv25aGl6/erAObWhWRtf9j4I8XqA8JN6Tbxh3ONGpcp3wNNd03s/yQ+TBGoCfWI2cQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.38.tgz",
+      "integrity": "sha512-GoYqWrbwEQty36dUzjbBoIBW+hymFrE8S7IifH6Lzess3a9z9ST1APNYk4XHrGYYyn7lOGOWe3SL8tPLWoo+OA==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.38.tgz",
+      "integrity": "sha512-aqGomD8WO9Ne/agQBxXQy8XhalSF3awhOs/NmicxtttXHblFxEj14HSio1gWKfKpt2Er1d2DnWOD3i2o9X9hQg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.38",
+        "@babel/helper-define-map": "7.0.0-beta.38",
+        "@babel/helper-function-name": "7.0.0-beta.38",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.38",
+        "@babel/helper-replace-supers": "7.0.0-beta.38",
+        "globals": "11.2.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.38.tgz",
+      "integrity": "sha512-n2ZUN8FOdmddAe1+bgPARU274hKGP4dVfnHDzytmxh/vuH1cbWfJ/lbzZJO5O3+zchv3syCdSQpnxHueJ4+cCw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.38.tgz",
+      "integrity": "sha512-3DD17TSYkgmwBO+12pO3LP6RK8Pv7EGTLYOfBDU217mMnmC+xaGi4I5BFlTroK+1+IJLys3ObetRMobV4VU0bQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.38.tgz",
+      "integrity": "sha512-MYjo3Fg3EjmAcZBG+gnbP8HjdmkoRpjGV68+Q9w853Ye9VimO47bz9HBojsClYpXsXbyxNbPRZteGU/jrMcKig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.38",
+        "regexpu-core": "4.1.3"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.38.tgz",
+      "integrity": "sha512-FRHj7ukkoPV1yZEU22BjdlJYEox5voH6FPxrqJHiTYtk89h8PmKotbnYjMagNniAQ+tZ1iZYY229ntrgNN35Ww==",
+      "dev": true
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.38.tgz",
+      "integrity": "sha512-6FyrtyZswMw9rhf25hXoZEGWhuleB8zWdzU7kmgh1Pztm/Xv4tVBUHMevbOZIt3KCJQucpwhb/T58FrZ/mPwcg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ui9oNgRvVNYzJeYbOmNCL1UIr1++7twyiYIuzOuQ9ArSF1WOaO4fluQa43zccgWRd610CRkljNRszag0aKB4Wg==",
+      "dev": true
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.38.tgz",
+      "integrity": "sha512-jvkRISpOr8b+bsnQ3d7oNgjUJqrtME2T8ken0Z8o98TY3YdFGwQVdpyWgoe5JKA5iV9WQK131en+LHj169R6gA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.38.tgz",
+      "integrity": "sha512-pNx7CUnGOR74fkpvzIho5GECAgaf0m0px7GZ2uzNYGMm5nvUT3h2bA6ASjI0YQ7FLHQScRdrHa0rBvD7lSIZFQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.38.tgz",
+      "integrity": "sha512-BafGOUA0G8qmClL365eUqs4ty4fVeVUdwZhWrYvLuxDInOCwYmGfWk6se8Gnvg4CGKZmlKojpzwwJFNHSjJKXg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ZOQ9vK2+FF3pYxjtqQkMoGkU2x8yMOWmc/DBCGptXN5F7ypOLE1DYl1qj+5j/PHLcLTBkZMTuC2yvjYdWQEn1A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.38",
+        "@babel/helper-simple-access": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.38.tgz",
+      "integrity": "sha512-iS7AVaR46bdzx6mHFyc69P2EDt9Dk/U+q2a/hdWrKo6JKdyquYC1O2saaCVTR7/o9pYrgk/xdAKyZGNvpNrLaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.38.tgz",
+      "integrity": "sha512-3Y83CIc1fybCmdYe5zQQ9yP7v5989Gg9x/0SGE0s5Uuwo5g8hj+t2nahvE4b4Uq03NYYnmClkhXi8Va7wvM1Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.38.tgz",
+      "integrity": "sha512-6xzyPp1GgyB0nNtsX9GmYWGVEOCkSIuTf8yJlGp/X/vrWNNxnlYl0D4IqySerzkHo2bABCES7sw/5A2ZYVRhtQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.38.tgz",
+      "integrity": "sha512-aPhCJ+JFKt4/o8q9tLQUIfX4qQrFcsHzax5dkO7Xj1VZGZ0RZnJbsR32k0oI5/XhOVnyppLDAvkDOcEo7rm1hg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-replace-supers": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.38.tgz",
+      "integrity": "sha512-D8aOMPvzGSJ+7uDPoanWlZNM7/F6F6kffvT7f63qQtjktikwusknduy/4jXhEWWeOaQcUcDbirvxVT0abTS6SQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "7.0.0-beta.38",
+        "@babel/helper-get-function-arity": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.38.tgz",
+      "integrity": "sha512-jbvExdAuxDndPbK3oO54QdkKqMeUAt/XYMW9wovYAWLA5R2loJkMjneZ5iU8VbfNcqVk2baWdgInBBUy6dtoXQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.12.3"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.38.tgz",
+      "integrity": "sha512-oEFwjJhfP2/mtVJ/v6PnE2g4zYHX2/xuLiT9x9spLU6q2kutKsBm7MX5gcyuT4WGk9t2r7ZGYXi8mBJ4qYMwOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.38.tgz",
+      "integrity": "sha512-XeDeMOpDYRg69lErxWK+vHOQhZNU4Pui4HJWhsd7Sqw2MQL4/OYi6IQLfBmcJnGimnhUEQOONCyjcIkmeQxXJw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.38.tgz",
+      "integrity": "sha512-KQItm2CD8JthjpcmccTEoi4db9AJ0C4vPBy5Ds/AuIBqmFKBkWVanzyciUsX5yupNrZRYcbnCQ2hflDUpFIN8Q==",
+      "dev": true
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.38.tgz",
+      "integrity": "sha512-kwH7JLQ+UqDJK4ZkEimL/mMrRSTS/Agm8+EzEJomgr2P2xzSI7fHQ4a6F4m6PFFk3ZUpdF2TDp1V/7q4Hy8Etg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.38.tgz",
+      "integrity": "sha512-YhOcJEawsIStf6OnPousctP6MXsxl4ujvqW3uMHp4NUX4on2q4puQpNO8+yZbjD+JTInIPBvM1/GTwpzPgryQA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.38.tgz",
+      "integrity": "sha512-vVULLUBkiLj4Y/p/37jxnutyOW0Ho0k6W2Own2wRe/kcWQoHxTDwwDWU2tGGBed1u1jbbYw5+B26F9IQ63tkvg==",
+      "dev": true
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.38.tgz",
+      "integrity": "sha512-yDlQX//HQusXLy+ujZvgt8JTKSU6b71/77KINIXb6utsegiy2qkJq6eoqmidpBh78ncEnK9zgtLjY3wt1PBDYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.38",
+        "regexpu-core": "4.1.3"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.38.tgz",
+      "integrity": "sha512-essqHthkBgeTvAzNAEie3Bvox5PZpJIzbajeWfFYvJTwUBvh6/MFhXlUmgNuu4lVqPrK+oME8oyHaOHKOgZTNg==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-check-constants": "7.0.0-beta.38",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.38",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.38",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.38",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.38",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.38",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.38",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.38",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.38",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.38",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.38",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.38",
+        "@babel/plugin-transform-classes": "7.0.0-beta.38",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.38",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.38",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.38",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.38",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.38",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.38",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.38",
+        "@babel/plugin-transform-literals": "7.0.0-beta.38",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.38",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.38",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.38",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.38",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.38",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.38",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.38",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.38",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.38",
+        "@babel/plugin-transform-spread": "7.0.0-beta.38",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.38",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.38",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.38",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.38",
+        "browserslist": "2.11.3",
+        "invariant": "2.2.2",
+        "semver": "5.5.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ZvPtlcvH2ZRzr1U5pkmCE7U3RIun3Nf29XHem47aScmJgMuL06ulkp+4oPBee3QrUVFErDjwNWtC67BzNuxLVw==",
+      "requires": {
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ygOSe1+ekKVkn5zxCH0rqv5sZtvLfC72yPQSaXLTHtYSYdAyXNqOW7q1ua1zJll9glk0UWYAnUEcehQXXc3fEA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38",
+        "babylon": "7.0.0-beta.38",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.38.tgz",
+      "integrity": "sha512-qbrc59aPCnMCj3uroG7QXdFMmrFLFvEfcwfVzmF2MXh2a7OhRzs73g/PNN8Xb0W/4Z1H4ZTY95CczmfDmXapnw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.38",
+        "@babel/generator": "7.0.0-beta.38",
+        "@babel/helper-function-name": "7.0.0-beta.38",
+        "@babel/types": "7.0.0-beta.38",
+        "babylon": "7.0.0-beta.38",
+        "debug": "3.1.0",
+        "globals": "11.2.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.38.tgz",
+      "integrity": "sha512-SAtyEjmA7KiEoL2eAOAUM6M9arQJGWxJKK0S9x0WyPOosHS420RXoxPhn57u/8orRnK8Kxm0nHQQNTX203cP1Q==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      }
+    },
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -84,10 +713,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "anymatch": {
       "version": "1.3.2",
@@ -151,9 +783,9 @@
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -171,9 +803,9 @@
       }
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -194,72 +826,39 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
-      }
-    },
-    "babel-eslint": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0",
-        "regenerator-runtime": "0.11.0"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ukc+RoVsxNjsFGTgXtCGr/RcNHQ4/OKBZQ2B6C2XBQwrbxXGWxgOMF9xgQ2WAQJQtvur3N6xakpIGMRNfGtt8Q==",
       "dev": true
     },
     "balanced-match": {
@@ -275,21 +874,21 @@
       "dev": true
     },
     "big.js": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-      "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "bn.js": {
@@ -332,16 +931,17 @@
       "dev": true
     },
     "browserify-aes": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
-      "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
         "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.0",
-        "inherits": "2.0.3"
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "browserify-cipher": {
@@ -350,9 +950,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.0.6",
+        "browserify-aes": "1.1.1",
         "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.0"
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -373,7 +973,7 @@
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -392,12 +992,22 @@
       }
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "1.0.6"
+      }
+    },
+    "browserslist": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000792",
+        "electron-to-chromium": "1.3.31"
       }
     },
     "buffer": {
@@ -450,7 +1060,7 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1",
+        "no-case": "2.3.2",
         "upper-case": "1.1.3"
       }
     },
@@ -458,6 +1068,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+      "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI=",
       "dev": true
     },
     "center-align": {
@@ -471,16 +1087,14 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "4.5.0"
       }
     },
     "chokidar": {
@@ -491,7 +1105,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -517,12 +1131,12 @@
       "dev": true
     },
     "clean-css": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.7.tgz",
-      "integrity": "sha1-ua6k+FZ5iJzz6ui0A0nsTr390DI=",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+      "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "cli-cursor": {
@@ -535,9 +1149,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -571,10 +1185,25 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
       "dev": true
     },
     "concat-map": {
@@ -609,11 +1238,16 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -640,7 +1274,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.8"
+        "sha.js": "2.4.10"
       }
     },
     "create-hmac": {
@@ -654,7 +1288,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "sha.js": "2.4.10"
       }
     },
     "cross-spawn": {
@@ -669,9 +1303,9 @@
       }
     },
     "crypto-browserify": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -681,9 +1315,10 @@
         "create-hmac": "1.1.6",
         "diffie-hellman": "5.0.2",
         "inherits": "2.0.3",
-        "pbkdf2": "3.0.13",
+        "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.3"
       }
     },
     "css-select": {
@@ -710,7 +1345,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.29"
+        "es5-ext": "0.10.38"
       }
     },
     "date-now": {
@@ -720,9 +1355,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -740,15 +1375,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
-    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -761,7 +1387,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "des.js": {
@@ -781,18 +1407,17 @@
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
-        "miller-rabin": "4.0.0",
-        "randombytes": "2.0.5"
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dom-converter": {
@@ -831,9 +1456,9 @@
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "domelementtype": {
@@ -860,6 +1485,12 @@
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+      "dev": true
     },
     "elliptic": {
       "version": "6.4.0",
@@ -901,12 +1532,12 @@
       "dev": true
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -918,46 +1549,24 @@
         "is-arrayish": "0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
     "es5-ext": {
-      "version": "0.10.29",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
-      "integrity": "sha512-KXla9NXo5sdaEkGSmbFPYgjH6m75kxsthL6GDRSug/Y2OiMoYm0I9giL39j4cgmaFmAbkIFJ6gG+SGKnLSmOvA==",
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
+        "es5-ext": "0.10.38",
         "es6-symbol": "3.1.1"
       }
     },
@@ -968,8 +1577,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -982,8 +1591,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
@@ -995,7 +1604,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29"
+        "es5-ext": "0.10.38"
       }
     },
     "es6-weak-map": {
@@ -1005,8 +1614,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1037,22 +1646,22 @@
         "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.8",
-        "doctrine": "2.0.0",
+        "debug": "2.6.9",
+        "doctrine": "2.1.0",
         "escope": "3.6.0",
-        "espree": "3.5.0",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
+        "is-my-json-valid": "2.17.1",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -1069,6 +1678,48 @@
         "table": "3.8.3",
         "text-table": "0.2.0",
         "user-home": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "eslint-config-google": {
@@ -1078,12 +1729,12 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -1131,7 +1782,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29"
+        "es5-ext": "0.10.38"
       }
     },
     "events": {
@@ -1141,12 +1792,13 @@
       "dev": true
     },
     "evp_bytestokey": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
-      "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "execa": {
@@ -1209,6 +1861,12 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -1231,7 +1889,7 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -1264,9 +1922,9 @@
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -1290,10 +1948,11 @@
         "for-in": "1.0.2"
       }
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1302,14 +1961,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -1467,7 +2126,6 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -1511,6 +2169,12 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1656,7 +2320,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -1828,11 +2491,13 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -2040,7 +2705,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -2200,11 +2864,6 @@
         }
       }
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -2266,9 +2925,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.2.0.tgz",
+      "integrity": "sha512-RDC7Tj17I/56wpVvCVLSXtnn2Fo6CQZ9vaj+ARn+qlzm/ozbKQZe+j9fvHZCbSq+4JSGjTpKEt7p/AA1IKXRFA==",
       "dev": true
     },
     "globby": {
@@ -2290,14 +2949,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
-    },
-    "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "requires": {
-        "function-bind": "1.1.1"
-      }
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -2357,19 +3008,27 @@
       "dev": true
     },
     "html-minifier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.3.tgz",
-      "integrity": "sha512-iKRzQQDuTCsq0Ultbi/mfJJnR0D3AdZKTq966Gsp92xkmAPCV4Xi08qhJ0Dl3ZAWemSgJ7qZK+UsZc0gFqK6wg==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.8.tgz",
+      "integrity": "sha512-WX7D6PB9PFq05fZ1/CyxPUuyqXed6vh2fGOM80+zJT5wAO93D/cUjLs0CcbBFjQmlwmCgRvl97RurtArIpOnkw==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
-        "clean-css": "4.1.7",
-        "commander": "2.11.0",
+        "clean-css": "4.1.9",
+        "commander": "2.12.2",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.0.28"
+        "uglify-js": "3.3.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "html-webpack-plugin": {
@@ -2378,12 +3037,12 @@
       "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
-        "html-minifier": "3.5.3",
+        "bluebird": "3.5.1",
+        "html-minifier": "3.5.8",
         "loader-utils": "0.2.17",
         "lodash": "4.17.4",
         "pretty-error": "2.1.1",
-        "toposort": "1.0.3"
+        "toposort": "1.0.6"
       }
     },
     "htmlparser2": {
@@ -2434,9 +3093,9 @@
       }
     },
     "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "ieee754": {
@@ -2446,9 +3105,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -2489,7 +3148,7 @@
         "ansi-regex": "2.1.1",
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "figures": "1.7.0",
         "lodash": "4.17.4",
         "readline2": "1.0.1",
@@ -2498,12 +3157,39 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "invariant": {
@@ -2533,13 +3219,13 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -2550,16 +3236,6 @@
       "requires": {
         "builtin-modules": "1.1.1"
       }
-    },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2607,9 +3283,9 @@
       }
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -2639,17 +3315,23 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -2669,33 +3351,17 @@
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "1.0.1"
-      }
-    },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "isarray": {
       "version": "1.0.0",
@@ -2719,20 +3385,20 @@
       }
     },
     "jasmine": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.7.0.tgz",
-      "integrity": "sha1-XPC7TllLRgC7QjVWA2YhKsWuobI=",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.9.0.tgz",
+      "integrity": "sha1-dlcfklyHg0CefGFTVy5aY0HPk+s=",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
         "glob": "7.1.2",
-        "jasmine-core": "2.7.0"
+        "jasmine-core": "2.9.1"
       }
     },
     "jasmine-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.7.0.tgz",
-      "integrity": "sha1-UP+MT5LY71wLLBuEbdJj7YUVIJE=",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.9.1.tgz",
+      "integrity": "sha1-trvB2OZSUNVvWIhGFwXr7uuI8i8=",
       "dev": true
     },
     "js-tokens": {
@@ -2742,14 +3408,20 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
       }
+    },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "dev": true
     },
     "json-loader": {
       "version": "0.5.7",
@@ -2796,7 +3468,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -2848,7 +3520,7 @@
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
-        "big.js": "3.1.3",
+        "big.js": "3.2.0",
         "emojis-list": "2.1.0",
         "json5": "0.5.1",
         "object-assign": "4.1.1"
@@ -2901,6 +3573,28 @@
         "yallist": "2.1.2"
       }
     },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "dev": true,
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -2916,7 +3610,7 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
+        "errno": "0.1.6",
         "readable-stream": "2.3.3"
       }
     },
@@ -2938,13 +3632,13 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
-      "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -3006,9 +3700,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
     },
@@ -3028,51 +3722,43 @@
       }
     },
     "no-case": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
-      "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
         "lower-case": "1.1.4"
       }
     },
     "node-libs-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
         "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
+        "browserify-zlib": "0.2.0",
         "buffer": "4.9.1",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.1",
-        "domain-browser": "1.1.7",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
         "events": "1.1.1",
-        "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
         "process": "0.11.10",
         "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.4",
+        "stream-http": "2.8.0",
+        "string_decoder": "1.0.3",
+        "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
         "vm-browserify": "0.0.4"
-      },
-      "dependencies": {
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
     "normalize-package-data": {
@@ -3083,7 +3769,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -3123,12 +3809,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
@@ -3138,17 +3820,6 @@
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
-      }
-    },
-    "object.values": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
       }
     },
     "once": {
@@ -3181,9 +3852,9 @@
       }
     },
     "os-browserify": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "os-homedir": {
@@ -3203,6 +3874,17 @@
         "mem": "1.1.0"
       }
     },
+    "output-file-sync": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.0.tgz",
+      "integrity": "sha1-XTSKGh6u0a0WhkigGi1tEweM6Yc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "is-plain-obj": "1.1.0",
+        "mkdirp": "0.5.1"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -3210,10 +3892,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -3221,13 +3906,19 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
     },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
     "param-case": {
@@ -3236,7 +3927,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1"
+        "no-case": "2.3.2"
       }
     },
     "parse-asn1": {
@@ -3245,11 +3936,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.6",
+        "asn1.js": "4.9.2",
+        "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.0",
-        "pbkdf2": "3.0.13"
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
       }
     },
     "parse-glob": {
@@ -3319,16 +4010,16 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
-      "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "sha.js": "2.4.10"
       }
     },
     "pify": {
@@ -3380,6 +4071,12 @@
         "utila": "0.4.0"
       }
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3399,9 +4096,9 @@
       "dev": true
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
@@ -3420,7 +4117,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "punycode": {
@@ -3466,7 +4163,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -3477,17 +4174,27 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "dev": true,
+      "requires": {
+        "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -3556,23 +4263,82 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
+      }
+    },
+    "regenerate": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
+      "integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3"
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-      "dev": true
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
-    "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+    "regenerator-transform": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.3.tgz",
+      "integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "private": "0.1.8"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regexpu-core": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+      "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3",
+        "regenerate-unicode-properties": "5.1.3",
+        "regjsgen": "0.3.0",
+        "regjsparser": "0.2.1",
+        "unicode-match-property-ecmascript": "1.0.3",
+        "unicode-match-property-value-ecmascript": "1.0.1"
+      }
+    },
+    "regjsgen": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+      "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+      "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
       }
     },
     "relateurl": {
@@ -3643,9 +4409,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -3677,9 +4443,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -3717,9 +4483,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "set-blocking": {
@@ -3741,12 +4507,13 @@
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
-      "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "shebang-command": {
@@ -3771,7 +4538,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.3",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
     },
@@ -3779,6 +4546,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "slice-ansi": {
@@ -3794,9 +4567,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "spdx-correct": {
@@ -3837,9 +4610,9 @@
       }
     },
     "stream-http": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -3897,10 +4670,13 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
     },
     "table": {
       "version": "3.8.3",
@@ -3922,6 +4698,25 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3936,16 +4731,24 @@
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
           }
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -3968,9 +4771,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+      "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
@@ -3983,21 +4786,21 @@
       "dev": true
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "toposort": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz",
-      "integrity": "sha1-8CzYp0vYvi/A6YYRw7rLlaFxhpw=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
+      "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
       "dev": true
     },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "tty-browserify": {
@@ -4022,13 +4825,21 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
-      "integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.8.tgz",
+      "integrity": "sha512-X0jAGtpSZRtd4RhbVNuGHyjZNa/h2MrVkKrR3Ew5iL2MJw6d7FmBke+fhVCALWySv1ygHnjjROG1KI1FAPvddw==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "source-map": "0.5.6"
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "uglify-to-browserify": {
@@ -4044,9 +4855,9 @@
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "uglify-js": "2.8.29",
-        "webpack-sources": "1.0.1"
+        "webpack-sources": "1.1.0"
       },
       "dependencies": {
         "uglify-js": {
@@ -4055,7 +4866,7 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.6",
+            "source-map": "0.5.7",
             "uglify-to-browserify": "1.0.2",
             "yargs": "3.10.0"
           }
@@ -4073,6 +4884,34 @@
           }
         }
       }
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "1.0.3",
+        "unicode-property-aliases-ecmascript": "1.0.3"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
+      "integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w==",
+      "dev": true
     },
     "upper-case": {
       "version": "1.1.3",
@@ -4161,57 +5000,57 @@
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
       }
     },
     "webpack": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.5.tgz",
-      "integrity": "sha512-qeUx4nIbeLL53qqNTs3kObPBMkUVDrOjEfp/hTvMlx21qL2MsGNr8/tXCoX/lS12dLl9qtZaXv2qfBEctPScDg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.3.0",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.2.2",
-        "ajv-keywords": "2.1.0",
-        "async": "2.5.0",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
-        "interpret": "1.0.3",
+        "interpret": "1.1.0",
         "json-loader": "0.5.7",
         "json5": "0.5.1",
         "loader-runner": "2.3.0",
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
         "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
-        "source-map": "0.5.6",
-        "supports-color": "4.2.1",
+        "node-libs-browser": "2.1.0",
+        "source-map": "0.5.7",
+        "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.4.0",
-        "webpack-sources": "1.0.1",
+        "webpack-sources": "1.1.0",
         "yargs": "8.0.2"
       },
       "dependencies": {
         "ajv": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ajv-keywords": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
           "dev": true
         },
         "loader-utils": {
@@ -4220,30 +5059,29 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "3.1.3",
+            "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
-          }
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
           }
         }
       }
     },
     "webpack-sources": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+      "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",
-        "source-map": "0.5.6"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,13 @@
 {
   "name": "preload-webpack-plugin",
-  "version": "2.2.0",
-  "description": "Enhances html-webpack-plugin with link rel=preload wiring capabilities for scripts",
-  "main": "index.js",
-  "scripts": {
-    "lint": "eslint --quiet -f codeframe index.js test/spec.js",
-    "lint-fix": "eslint --fix --quiet -f codeframe index.js test/spec.js",
-    "test": "node_modules/jasmine/bin/jasmine.js test/spec.js"
+  "version": "3.0.0",
+  "description": "A webpack plugin for injecting <link rel='preload|prefecth'> into HtmlWebpackPlugin pages, with async chunk support",
+  "author": "Addy Osmani <addy.osmani@gmail.com> (https://github.com/addyosmani)",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/googlechromelabs/preload-webpack-plugin/issues"
   },
-  "files": [
-    "index.js"
-  ],
+  "homepage": "https://github.com/googlechromelabs/preload-webpack-plugin",
   "repository": {
     "type": "git",
     "url": "https://github.com/googlechromelabs/preload-webpack-plugin.git"
@@ -23,25 +20,35 @@
     "preload",
     "resource hints"
   ],
-  "author": "Addy Osmani <addy.osmani@gmail.com> (https://github.com/addyosmani)",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/googlechromelabs/preload-webpack-plugin/issues"
+  "engines": {
+    "node": ">=4.0.0"
   },
-  "homepage": "https://github.com/googlechromelabs/preload-webpack-plugin",
+  "scripts": {
+    "lint": "eslint --format=codeframe .",
+    "test": "jasmine test/spec.js",
+    "clean": "rimraf build",
+    "build": "npm run clean && babel --out-dir=build src"
+  },
+  "main": "build/index.js",
+  "files": [
+    "build"
+  ],
   "devDependencies": {
-    "babel-eslint": "^7.1.1",
+    "@babel/cli": "^7.0.0-beta.38",
+    "@babel/core": "^7.0.0-beta.38",
+    "@babel/plugin-transform-runtime": "^7.0.0-beta.38",
+    "@babel/preset-env": "^7.0.0-beta.38",
     "eslint": "^3.14.1",
     "eslint-config-google": "^0.7.1",
     "html-webpack-plugin": "^2.26.0",
     "jasmine": "^2.5.3",
+    "rimraf": "^2.6.2",
     "webpack": "^3.2.0"
   },
   "peerDependencies": {
     "webpack": "^3.2.0"
   },
   "dependencies": {
-    "object-assign": "^4.1.1",
-    "object.values": "^1.0.4"
+    "@babel/runtime": "^7.0.0-beta.38"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,16 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-// See https://github.com/GoogleChromeLabs/preload-webpack-plugin/issues/45
-require('object.values').shim();
+const DEFAULT_OPTIONS = {
+  rel: 'preload',
+  include: 'asyncChunks',
+  fileBlacklist: [/\.map/]
+};
 
-const objectAssign = require('object-assign');
+function flatten(arr) {
+  return arr.reduce((prev, curr) => prev.concat(curr), []);
+}
 
-const flatten = arr => arr.reduce((prev, curr) => prev.concat(curr), []);
-
-const doesChunkBelongToHTML = (chunk, roots, visitedChunks) => {
+function doesChunkBelongToHTML(chunk, roots, visitedChunks) {
   // Prevent circular recursion.
   // See https://github.com/GoogleChromeLabs/preload-webpack-plugin/issues/49
   if (visitedChunks[chunk.renderedHash]) {
@@ -44,17 +46,11 @@ const doesChunkBelongToHTML = (chunk, roots, visitedChunks) => {
   }
 
   return false;
-};
-
-const defaultOptions = {
-  rel: 'preload',
-  include: 'asyncChunks',
-  fileBlacklist: [/\.map/]
-};
+}
 
 class PreloadPlugin {
   constructor(options) {
-    this.options = objectAssign({}, defaultOptions, options);
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options);
   }
 
   apply(compiler) {

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    jasmine: true,
+  },
+};

--- a/test/spec.js
+++ b/test/spec.js
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-env jasmine */
-'use strict';
 
 const path = require('path');
 const MemoryFileSystem = require('memory-fs');


### PR DESCRIPTION
R: @addyosmani 

Fixes #47 

I'm making a few breaking changes in advance of a planned 3.0.0 release. I wanted to start with adding in `@babel/preset-env` transpilation as part of the build process, currently targeted node v4 (though this can change once node v4 [exits LTS](https://github.com/nodejs/Release#release-schedule)).

Along with babel transpilation, I've simplified the linting to account for the fact that we should honor anything in ES2017 (with a few tweaks to accommodate the current codebase), and adjusted `package.json` metadata to publish the transpiled output.