### PR TITLE
Add excludeHtmlNames to solve problem mentioned in https://github.com/GoogleChromeLabs/preload-webpack-plugin/issues/48

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ new PreloadWebpackPlugin({
 })
 ```
 
+## Filtering Html
+
+In some case, you may don't want to preload resource on some file. But using `fileBlacklist`  is werid, because you may want to inlcude this chunk on another file. So you can use `excludeHtmlNames` to tell preload plugin to ignore this file.
+
+If you have multiple html like index.html and example.html, you can exclude index.html like this.
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin({
+    filename: 'index.html',
+    template: 'src/index.html',
+    chunks: ['main']
+  }),
+  new HtmlWebpackPlugin({
+    filename: 'example.html',
+    template: 'src/example.html',
+    chunks: ['exampleEntry']
+  }),
+  // I want this to affect only index.html
+  new PreloadWebpackPlugin({
+    excludeHtmlNames: ['index.html'],
+  })     
+]
+```
+
 Resource Hints
 ---------------------
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ const doesChunkBelongToHTML = (chunk, roots, visitedChunks) => {
 const defaultOptions = {
   rel: 'preload',
   include: 'asyncChunks',
-  fileBlacklist: [/\.map/]
+  fileBlacklist: [/\.map/],
+  excludeHtmlNames: [],
 };
 
 class PreloadPlugin {
@@ -61,6 +62,10 @@ class PreloadPlugin {
     const options = this.options;
     compiler.plugin('compilation', compilation => {
       compilation.plugin('html-webpack-plugin-before-html-processing', (htmlPluginData, cb) => {
+        if (this.options.excludeHtmlNames.indexOf(htmlPluginData.plugin.options.filename) > -1) {
+          cb(null, htmlPluginData);
+          return;
+        }
         let filesToInclude = '';
         let extractedChunks = [];
         // 'asyncChunks' are chunks intended for lazy/async loading usually generated as

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "preload-webpack-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
In some case, you may don't want to preload resource on some file. But using `fileBlacklist`  is werid, because you may want to inlcude this chunk on another file. So you can use `excludeHtmlNames` to tell preload plugin to ignore this file.

If you have multiple html like index.html and example.html, you can exclude index.html like this.

```javascript
plugins: [
  new HtmlWebpackPlugin({
    filename: 'index.html',
    template: 'src/index.html',
    chunks: ['main']
  }),
  new HtmlWebpackPlugin({
    filename: 'example.html',
    template: 'src/example.html',
    chunks: ['exampleEntry']
  }),
  // I want this to affect only index.html
  new PreloadWebpackPlugin({
    excludeHtmlNames: ['index.html'],
  })     
]
```