### PR TITLE
 Allow passing a function to `options.rel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ new PreloadWebpackPlugin({
 })
 ```
 
+Moreover, if you need more control over what to include, have a look at [this](#resource-hints).
+
 ## Filtering Html
 
 In some case, you may don't want to preload resource on some file. But using `fileBlacklist`  is werid, because you may want to inlcude this chunk on another file. So you can use `excludeHtmlNames` to tell preload plugin to ignore this file.
@@ -226,6 +228,27 @@ For the async chunks mentioned earlier, the plugin would update your HTML to the
 ```html
 <link rel="prefetch" href="chunk.31132ae6680e598f8879.js">
 <link rel="prefetch" href="chunk.d15e7fdfc91b34bb78c4.js">
+```
+
+If you want to decide `prefetch` or `preload` (or ignore) by your custom logic, you can pass a function to the plugin:
+
+```js
+plugins: [
+  new HtmlWebpackPlugin(),
+  new PreloadWebpackPlugin({
+    rel: function(params) {
+      // This function will be invoked per-html-per-chunk.
+      var filename = params.filename; // HTML filename
+      var entry = params.entry; // chunk filename, includes publicPath (not chunk name!)
+      var htmlPluginData = params.htmlPluginData; // refer to html-webpack-plugin docs
+      var options = params.options; // the option itself, in case you need it
+      // ...
+      // return 'preload';
+      // return 'prefetch';
+      return null; // if you return undefined, null, or '', this chunk will not be injected to this html.
+    }
+  })
+]
 ```
 
 Demo

--- a/index.js
+++ b/index.js
@@ -111,7 +111,20 @@ class PreloadPlugin {
           return this.options.fileBlacklist.every(regex => regex.test(entry) === false);
         }).forEach(entry => {
           entry = `${publicPath}${entry}`;
-          if (options.rel === 'preload') {
+          let relValue;
+          if (!options.rel) {
+            relValue = 'preload';
+          } else if (typeof options.rel === 'function') {
+            relValue = options.rel({
+              filename: htmlPluginData.plugin.options.filename,
+              entry,
+              htmlPluginData,
+              options,
+            });
+          } else {
+            relValue = options.rel;
+          }
+          if (relValue === 'preload') {
             // If `as` value is not provided in option, dynamically determine the correct
             // value depends on suffix of filename. Otherwise use the given `as` value.
             let asValue;
@@ -125,12 +138,12 @@ class PreloadPlugin {
               asValue = options.as;
             }
             const crossOrigin = asValue === 'font' ? 'crossorigin="crossorigin" ' : '';
-            filesToInclude+= `<link rel="${options.rel}" as="${asValue}" ${crossOrigin}href="${entry}">\n`;
+            filesToInclude+= `<link rel="${relValue}" as="${asValue}" ${crossOrigin}href="${entry}">\n`;
           } else {
             // If preload isn't specified, the only other valid entry is prefetch here
             // You could specify preconnect but as we're dealing with direct paths to resources
             // instead of origins that would make less sense.
-            filesToInclude+= `<link rel="${options.rel}" href="${entry}">\n`;
+            filesToInclude+= `<link rel="${relValue}" href="${entry}">\n`;
           }
         });
         if (htmlPluginData.html.indexOf('</head>') !== -1) {

--- a/index.js
+++ b/index.js
@@ -121,6 +121,10 @@ class PreloadPlugin {
               htmlPluginData,
               options,
             });
+            if (!relValue) {
+              // no rel specified, ignore this chunk
+              return;
+            }
           } else {
             relValue = options.rel;
           }

--- a/test/spec.js
+++ b/test/spec.js
@@ -78,6 +78,38 @@ describe('PreloadPlugin preloads or prefetches async chunks', function() {
     compiler.outputFileSystem = new MemoryFileSystem();
   });
 
+  it('adds dynamic prefetch tags to async chunks', function(done) {
+    const relFunction = function(params) {
+      expect(params.filename).toBe('index.html');
+      expect(params.entry).toMatch(/^\/chunk\.[0-9a-f]+\.js$/);
+      return 'prefetch';
+    };
+    const compiler = webpack({
+      entry: {
+        js: path.join(__dirname, 'fixtures', 'file.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'bundle.js',
+        chunkFilename: 'chunk.[chunkhash].js',
+        publicPath: '/',
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new PreloadPlugin({
+          rel: relFunction
+        })
+      ]
+    }, function(err, result) {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(result.compilation.errors)).toBe('[]');
+      const html = result.compilation.assets['index.html'].source();
+      expect(html).toContain('<link rel="prefetch" href="/chunk.');
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
+
   it('respects publicPath', function(done) {
     const compiler = webpack({
       entry: {
@@ -263,6 +295,37 @@ describe('PreloadPlugin prefetches normal chunks', function() {
         new HtmlWebpackPlugin(),
         new PreloadPlugin({
           rel: 'prefetch',
+          include: 'all'
+        })
+      ]
+    }, function(err, result) {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(result.compilation.errors)).toBe('[]');
+      const html = result.compilation.assets['index.html'].source();
+      expect(html).toContain('<link rel="prefetch" href="0');
+      expect(html).toContain('<link rel="prefetch" href="main.js"');
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
+});
+
+describe('PreloadPlugin dynamically preloads/prefetches normal chunks', function() {
+  it('adds prefetch tags', function(done) {
+    const relFunction = function(params) {
+      expect(params.filename).toBe('index.html');
+      expect(params.entry).toMatch(/0\.js|main\.js/);
+      return 'prefetch';
+    };
+    const compiler = webpack({
+      entry: path.join(__dirname, 'fixtures', 'file.js'),
+      output: {
+        path: OUTPUT_DIR
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new PreloadPlugin({
+          rel: relFunction,
           include: 'all'
         })
       ]


### PR DESCRIPTION
This allows a user add some custom logic to `options.rel` for deciding which chunks to preload, which to prefetch, and which to ignore.