### PR TITLE
Added option for excluding named chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,18 @@ class PreloadPlugin {
         });
     }
 
+    if (Array.isArray(options.exclude)) {
+      // Exclude user specified chunks
+      extractedChunks = extractedChunks.filter(chunk => {
+        const chunkName = chunk.name;
+        // Only care about named chunks
+        if (!chunkName) {
+          return true;
+        }
+        return !options.exclude.includes(chunkName);
+      });
+    }
+
     // only handle the chunks associated to this htmlWebpackPlugin instance, in case of multiple html plugin outputs
     // allow `allAssets` mode to skip, as assets are just files to be filtered by black/whitelist, not real chunks
     if (options.include !== 'allAssets') {
@@ -233,6 +245,18 @@ class PreloadPlugin {
           }
           return options.include.indexOf(chunkName) > -1;
         });
+    }
+
+    if (Array.isArray(options.exclude)) {
+      // Exclude user specified chunks
+      extractedChunks = extractedChunks.filter(chunk => {
+        const chunkName = chunk.name;
+        // Only care about named chunks
+        if (!chunkName) {
+          return true;
+        }
+        return !options.exclude.includes(chunkName);
+      });
     }
 
     // only handle the chunks associated to this htmlWebpackPlugin instance, in case of multiple html plugin outputs

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,9 +895,9 @@
       }
     },
     "clean-css": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.7.tgz",
-      "integrity": "sha1-ua6k+FZ5iJzz6ui0A0nsTr390DI=",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+      "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
         "source-map": "0.5.6"
@@ -1000,9 +1000,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
       "dev": true
     },
     "commondir": {
@@ -3171,42 +3171,34 @@
       "dev": true
     },
     "html-minifier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.3.tgz",
-      "integrity": "sha512-iKRzQQDuTCsq0Ultbi/mfJJnR0D3AdZKTq966Gsp92xkmAPCV4Xi08qhJ0Dl3ZAWemSgJ7qZK+UsZc0gFqK6wg==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.11.tgz",
+      "integrity": "sha512-kIi9C090qWW5cGxEf+EwNUczduyVR6krk29WB3zDSWBQN6xuh/1jCXgmY4SvqzaJMOZFCnf8wcNzA8iPsfLiUQ==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
-        "clean-css": "4.1.7",
-        "commander": "2.11.0",
+        "clean-css": "4.1.11",
+        "commander": "2.15.0",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.0.28"
+        "uglify-js": "3.3.15"
       }
     },
     "html-webpack-plugin": {
-      "version": "3.0.4",
-      "resolved": "http://registry.npm.taobao.org/html-webpack-plugin/download/html-webpack-plugin-3.0.4.tgz",
-      "integrity": "sha1-SYwQ9A+Zozn789h8WoCs+Mvqjps=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.0.6.tgz",
+      "integrity": "sha1-01sEUqrhKaip8/rEShaaYl2M8/o=",
       "dev": true,
       "requires": {
-        "html-minifier": "3.5.3",
+        "html-minifier": "3.5.11",
         "loader-utils": "0.2.17",
         "lodash": "4.17.4",
         "pretty-error": "2.1.1",
         "tapable": "1.0.0",
-        "toposort": "1.0.3",
+        "toposort": "1.0.6",
         "util.promisify": "1.0.0"
-      },
-      "dependencies": {
-        "tapable": {
-          "version": "1.0.0",
-          "resolved": "http://registry.npm.taobao.org/tapable/download/tapable-1.0.0.tgz",
-          "integrity": "sha1-y7Y52QAu7ZxrWXXrIFmNeTbx+fI=",
-          "dev": true
-        }
       }
     },
     "htmlparser2": {
@@ -4079,8 +4071,8 @@
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "http://registry.npm.taobao.org/no-case/download/no-case-2.3.2.tgz",
-      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
         "lower-case": "1.1.4"
@@ -4248,7 +4240,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "http://registry.npm.taobao.org/object.getownpropertydescriptors/download/object.getownpropertydescriptors-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
@@ -6012,9 +6004,9 @@
       }
     },
     "toposort": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz",
-      "integrity": "sha1-8CzYp0vYvi/A6YYRw7rLlaFxhpw=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
+      "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
       "dev": true
     },
     "trim-right": {
@@ -6051,13 +6043,21 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
-      "integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.15.tgz",
+      "integrity": "sha512-bqtBCAINYXX/OkdnqMGpbXr+OPWc00hsozRpk+dAtfnbdk2jjKiLmyOkQ7zamg648lVMnzATL8JrSN6LmaVpYA==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "source-map": "0.5.6"
+        "commander": "2.15.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "uglifyjs-webpack-plugin": {
@@ -6354,8 +6354,8 @@
     },
     "util.promisify": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/util.promisify/download/util.promisify-1.0.0.tgz",
-      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",


### PR DESCRIPTION
I think it's very important to be able to exclude specific chunks from the prefetch. A common use case is a chunk handling the admin route in the web app which might expose a security vulnurability if fetched by all clients.

I added functionality for providing an array with named chunks that should get excluded from the plugin.