### PR TITLE
compatible with html-webpack-plugin v4 hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ require('object.values').shim();
 
 const objectAssign = require('object-assign');
 
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
 const PLUGIN_NAME = 'preload-webpack-plugin';
 
 const weblog = require('webpack-log');
@@ -97,13 +99,15 @@ class PreloadPlugin {
 
   // handler use for webpack v4
   hooksHandler(compilation) {
-    if (!compilation.hooks.htmlWebpackPluginAfterHtmlProcessing) {
+    const beforeEmit = compilation.hooks.htmlWebpackPluginAfterHtmlProcessing ||
+      HtmlWebpackPlugin.getHooks(compilation).beforeEmit;
+    if (!beforeEmit) {
       const message = `compilation.hooks.htmlWebpackPluginAfterHtmlProcessing is lost.
       Please make sure you have installed html-webpack-plugin and put it before ${PLUGIN_NAME}`;
       log.error(message);
       throw new Error(message);
     }
-    compilation.hooks.htmlWebpackPluginAfterHtmlProcessing
+    beforeEmit
       .tapAsync(PLUGIN_NAME, (htmlPluginData, cb) => this.afterHtmlProcessingFn(htmlPluginData, cb, compilation));
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preload-webpack-plugin",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Enhances html-webpack-plugin with link rel=preload wiring capabilities for scripts",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,8 @@
     "webpack": "^4.1.0"
   },
   "peerDependencies": {
-    "webpack": "^4.0.1"
+    "webpack": "^4.0.1",
+    "html-webpack-plugin": "^3.0.6"
   },
   "dependencies": {
     "object-assign": "^4.1.1",


### PR DESCRIPTION
Addresses [this issue](https://github.com/GoogleChromeLabs/preload-webpack-plugin/issues/79) starting to pop up for those using the newer version (v4 beta) of Html Webpack Plugin`.

Preload Webpack Plugin depends on some hooks that are no longer placed onto the Webpack compilation object (with the "htmlWebpack" prefix), so it seems an explicit peer dependency might need to be adopted so that [its new static method `getHooks()`](https://github.com/jantimon/html-webpack-plugin/pull/953#issue-189369685) can be used.

Not sure if adopting a peer dependency is the best solution or not; let me know what you think.

Thanks!