### PR TITLE
fix incorrect keyword for crossorigin attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ class PreloadPlugin {
           } else {
             asValue = options.as;
           }
-          const crossOrigin = asValue === 'font' ? 'crossorigin="crossorigin" ' : '';
+          const crossOrigin = asValue === 'font' ? 'crossorigin="anonymous" ' : '';
           filesToInclude+= `<link rel="${options.rel}" as="${asValue}" ${crossOrigin}href="${entry}">\n`;
         } else {
           // If preload isn't specified, the only other valid entry is prefetch here


### PR DESCRIPTION
crossorigin attribute accepts either "anonymous" or "use-credentials". Here, it should use "anonymous" mode for font. Though invalid keyword will be treated as "anonymous", it's better to use the correct one.