### PR TITLE
Support inserting tags to arbitrary places

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,24 @@ plugins: [
   })
 ```
 
+## Control where the generated tags are inserted in the result HTML
+
+By default `PreloadWebpackPlugin` will insert the preload/prefetch tags in `<head></head>`.
+You can control the inserting point by overriding the default option.
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin({
+    filename: 'index.html',
+    template: 'src/index.html',
+    chunks: ['main']
+  }),
+  // I want to insert preload tags before this comment
+  new PreloadWebpackPlugin({
+    insertTagsBefore: '<!-- End of preload tags -->',
+  })
+```
+
 Resource Hints
 ---------------------
 

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ const defaultOptions = {
   include: 'asyncChunks',
   fileBlacklist: [/\.map/],
   excludeHtmlNames: [],
+  insertTagsBefore: '</head>'
 };
 
 class PreloadPlugin {
@@ -281,9 +282,9 @@ class PreloadPlugin {
           filesToInclude+= `<link rel="${options.rel}" href="${entry}">\n`;
         }
       });
-    if (htmlPluginData.html.indexOf('</head>') !== -1) {
-      // If a valid closing </head> is found, update it to include preload/prefetch tags
-      htmlPluginData.html = htmlPluginData.html.replace('</head>', filesToInclude + '</head>');
+    if (htmlPluginData.html.indexOf(this.options.insertTagsBefore) !== -1) {
+      // If a valid inserting point is found (default to </head>), update it to include preload/prefetch tags
+      htmlPluginData.html = htmlPluginData.html.replace(this.options.insertTagsBefore, filesToInclude + this.options.insertTagsBefore);
     } else {
       // Otherwise assume at least a <body> is present and update it to include a new <head>
       htmlPluginData.html = htmlPluginData.html.replace('<body>', '<head>' + filesToInclude + '</head><body>');


### PR DESCRIPTION
We don't generate full HTML page in our setup. We generate a HTML snippet then they are included as part of backend output (for some legacy reasons).
This PR adds ability to insert the tags to arbitrary places like comment.