### PR TITLE
add media option for responsive preloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,22 @@ For the async chunks mentioned earlier, the plugin would update your HTML to the
 <link rel="prefetch" href="chunk.d15e7fdfc91b34bb78c4.js">
 ```
 
+## Including media
+
+`<link>` elements have the ability to accept media attributes. These can accept media types or full-blown media queries, allowing you to do responsive preloading.
+
+You can pass the value for the media attribute in the `media` option:
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin(),
+  new PreloadWebpackPlugin({
+    rel: 'preload',
+    media: '(min-width: 600px)'
+  })
+]
+```
+
 ## Support
 
 If you've found an error or run into problems, please [file an issue](https://github.com/googlechrome/preload-webpack-plugin/issues).

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,11 @@ class PreloadPlugin {
         rel: options.rel,
       };
 
+      // See https://github.com/GoogleChromeLabs/preload-webpack-plugin/issues/69
+      if (options.media) {
+        attributes.media = options.media;
+      }
+
       // If we're preloading this resource (as opposed to prefetching),
       // then we need to set the 'as' attribute correctly.
       if (options.rel === 'preload') {


### PR DESCRIPTION
`<link>` elements have the ability to accept media attributes. These can accept media types or full-blown media queries, allowing you to do responsive preloading.

I've added the `media` option to pass the value for the media attribute, like so:

```javascript
plugins: [
  new HtmlWebpackPlugin(),
  new PreloadWebpackPlugin({
    rel: 'preload',
    media: '(min-width: 600px)'
  })
]
```

Fixes #69 