### PR TITLE
Added closingTagRequired to options 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ class PreloadPlugin {
       const linkElementString = createHTMLElementString({
         attributes,
         elementName: 'link',
+        closingTagRequired: options.closingTagRequired
       });
       links.push(linkElementString);
     }

--- a/src/lib/default-options.js
+++ b/src/lib/default-options.js
@@ -19,7 +19,8 @@ const defaultOptions = {
   rel: 'preload',
   include: 'asyncChunks',
   excludeHtmlNames: [],
-  fileBlacklist: [/\.map/]
+  fileBlacklist: [/\.map/],
+  closingTagRequired: false
 };
 
 module.exports = defaultOptions;


### PR DESCRIPTION
... and passing closingTagRequired to createHTMLElementString.
Needed for Razor pages, where closing tags or self-closing tags are obligatory.