### PR TITLE
Added closingTagRequired to Options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ class PreloadPlugin {
       const linkElementString = createHTMLElementString({
         attributes,
         elementName: 'link',
+        closingTagRequired: options.closingTagRequired
       });
       links.push(linkElementString);
     }

--- a/src/lib/default-options.js
+++ b/src/lib/default-options.js
@@ -19,7 +19,8 @@ const defaultOptions = {
   rel: 'preload',
   include: 'asyncChunks',
   excludeHtmlNames: [],
-  fileBlacklist: [/\.map/]
+  fileBlacklist: [/\.map/],
+  closingTagRequired: false
 };
 
 module.exports = defaultOptions;


### PR DESCRIPTION
Added closingTagRequired as Option and passing it to createHTMLElementString.
Necessary for Razor Pages where closing tags are obligatory.