### PR TITLE
Add option for entrpoint + preload/prefetch children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ class PreloadPlugin {
 
     const extractedChunks = extractChunks({
       compilation,
+      rel: options.rel,
       optionsInclude: options.include,
     });
 

--- a/test/unit/extract-chunk.js
+++ b/test/unit/extract-chunk.js
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const extractChunk = require('../../src/lib/extract-chunks');
+
+const stubEntrypoints = {
+  entry1: {
+    chunks: ['chunk1', 'chunk2'],
+    childAssets: {}
+  }
+};
+
+const stubEntrypointsWithPreloadedChildren = {
+  entry1: {
+    chunks: ['chunk1', 'chunk2'],
+    childAssets: {}
+  },
+  entry2: {
+    chunks: ['chunk3'],
+    childAssets: {preload: ['file4.js']}
+  }
+};
+
+const stubChunks = [
+  { id: 'chunk1', files: ['file1.js'] },
+  { id: 'chunk2', files: ['file2.js'] },
+  { id: 'chunk3', files: ['file3.js'] },
+];
+
+class StubCompilation {
+  constructor(entrypoints, chunks) {
+    this.entrypoints = entrypoints;
+    this.chunks = chunks;
+  }
+
+  getStats() {
+    return {
+      toJson: () => ({
+        entrypoints: this.entrypoints,
+        chunks: this.chunks
+      })
+    };
+  }
+}
+
+describe(`Entry and Children:`, function() {
+  it(`Includes entrypoints`, function() {
+    const compilation = new StubCompilation(stubEntrypoints, stubChunks);
+    const chunks = extractChunk({
+      compilation,
+      optionsInclude: 'entryAndChildren',
+      rel: 'preload'
+    });
+    expect(chunks).toEqual(stubChunks.slice(0, 2));
+  });
+
+  it(`Includes entrypoints and children`, function() {
+    const compilation = new StubCompilation(stubEntrypointsWithPreloadedChildren, stubChunks);
+    const chunks = extractChunk({
+      compilation,
+      optionsInclude: 'entryAndChildren',
+      rel: 'preload'
+    });
+    expect(chunks).toEqual(stubChunks.concat({files: ['file4.js']}));
+  });
+
+  it(`Only includes entrypoints matching the rel option`, function() {
+    const compilation = new StubCompilation(stubEntrypointsWithPreloadedChildren, stubChunks);
+    const chunks = extractChunk({
+      compilation,
+      optionsInclude: 'entryAndChildren',
+      rel: 'prefetch'
+    });
+    expect(chunks).toEqual(stubChunks);
+  });
+});

--- a/test/unit/extract-chunk.js
+++ b/test/unit/extract-chunk.js
@@ -36,9 +36,9 @@ const stubEntrypointsWithPreloadedChildren = {
 };
 
 const stubChunks = [
-  { id: 'chunk1', files: ['file1.js'] },
-  { id: 'chunk2', files: ['file2.js'] },
-  { id: 'chunk3', files: ['file3.js'] },
+  {id: 'chunk1', files: ['file1.js']},
+  {id: 'chunk2', files: ['file2.js']},
+  {id: 'chunk3', files: ['file3.js']},
 ];
 
 class StubCompilation {


### PR DESCRIPTION
Fixes #108 

## Description
- Adds link tags for entrypoints as well as any chunks which are prefetched or preloaded from an entrypoint via a magic comment

## Why
- If we use magic comments to preload bundles from an entrypoint, the bundle will not start loading until the parent as finished (See https://github.com/webpack/webpack/issues/8342#issuecomment-438649676)

## TODO
Submitted a PR to get early feedback on the approach but would need to do the following:
- [ ] Add to README
- [ ] This requires webpack >= 4.6.0 so we would either need to bump the peer dependency or make it clear that child assets will not be added in an older verions (would prefer the former)