### PR TITLE
Enable html-webpack-plugin inject: false option

### DIFF
--- a/src/lib/insert-links-into-head.js
+++ b/src/lib/insert-links-into-head.js
@@ -30,7 +30,7 @@ function insertLinksIntoHead({html, links=[]}) {
     return html.replace('<body>', `<head>${links.join('')}\n</head><body>`);
   }
 
-  throw new Error(`The HTML provided did not contain a </head> or a <body>:\n\n${html}`);
+  return links.join('') + html;
 }
 
 module.exports = insertLinksIntoHead;


### PR DESCRIPTION
Hi @jeffposnick 

Currently it's not possible to use html-webpack-plugin inject option set to false. I'm currently using this option to create an html file, which I include in the head of my CMS. I guess there will be more use cases like this, when there is no need of a head or body tag. What do you think?

Cheers,
Michael 